### PR TITLE
Add informative drop NA and duplicated value message.

### DIFF
--- a/R/Getters.R
+++ b/R/Getters.R
@@ -130,7 +130,7 @@ DpiGet <- function(url = 'http://bit.ly/1jZ3nmM', vars = NULL,
                    standardCountryName = TRUE, na.rm = TRUE,
                    duplicates = 'message', fromLast = FALSE){
     # Download underlying Dpi IV data
-    DpiData <- import(url)
+    DpiData <- import(url, format='dta')
     DpiData <- labelDataset(DpiData)
 
     # Clean up
@@ -152,7 +152,7 @@ DpiGet <- function(url = 'http://bit.ly/1jZ3nmM', vars = NULL,
     # Drop NAs for OutCountryID
     if (isTRUE(na.rm)) {
         DpiData <- DropNA.psData(data = DpiData,
-                                 timeVar='year',
+                                 countryVar = 'countryname', timeVar='year',
                                  OutCountryID=OutCountryID)
     }
     return(DpiData)

--- a/R/Getters.R
+++ b/R/Getters.R
@@ -69,7 +69,8 @@ PolityGet <- function(url = 'http://www.systemicpeace.org/inscr/p4v2012.sav',
   # Drop NAs for OutCountryID
     if (isTRUE(na.rm)) {
         PolityData <- DropNA.psData(data = PolityData,
-                        Var = OutCountryID)
+                                    timeVar='year',
+                                    OutCountryID=OutCountryID)
     }
     return(PolityData)
 }
@@ -151,7 +152,8 @@ DpiGet <- function(url = 'http://bit.ly/1jZ3nmM', vars = NULL,
     # Drop NAs for OutCountryID
     if (isTRUE(na.rm)) {
         DpiData <- DropNA.psData(data = DpiData,
-                        Var = OutCountryID)
+                                 timeVar='year',
+                                 OutCountryID=OutCountryID)
     }
     return(DpiData)
 }
@@ -462,7 +464,7 @@ IMF_WBGet <- function(url = 'http://axel-dreher.de/Dreher%20IMF%20and%20WB.xls',
 #'
 #' @seealso \code{\link{countrycode}}, \code{\link{CountryID}}
 #'
-#'  @importFrom rio import
+#' @importFrom rio import
 #'
 #' @export
 
@@ -471,7 +473,7 @@ DDGet <- function(url = 'http://uofi.box.com/shared/static/bba3968d7c3397c024ec.
                   standardCountryName = TRUE,
                   na.rm = TRUE, duplicates = 'message', fromLast = FALSE){
     # Download underlying Polity IV data
-    DDData <- rio::import(url)
+    DDData <- import(url)
 
     # Clean up
     DDData$order <- NULL
@@ -493,9 +495,10 @@ DDGet <- function(url = 'http://uofi.box.com/shared/static/bba3968d7c3397c024ec.
                         standardCountryName = standardCountryName,
                         fromLast = fromLast)
     # Drop NAs for OutCountryID
-    if (isTRUE(na.rm)){
+    if (isTRUE(na.rm) & duplicates != "return") {
         DDData <- DropNA.psData(data = DDData,
-                                Var = OutCountryID)
+                                timeVar='year',
+                                OutCountryID=OutCountryID)
     }
     return(DDData)
 }


### PR DESCRIPTION
Close #21 

In Getters.R:
- Typo fix: Use 'return', not 'out', to return duplicated values

In utils.R:
- Bug fix: Do not drop NA when users want to return duplicated values. This behavior is more consistent because we do count NA's when reporting the number of duplicates
- New feature: Informative duplicated and dropped NA message, specifying the country-years that were duplicated / dropped.